### PR TITLE
Added thumbnail to new post tableview

### DIFF
--- a/WordPress/Classes/NewPostTableViewCell.m
+++ b/WordPress/Classes/NewPostTableViewCell.m
@@ -94,8 +94,8 @@ CGFloat const NewPostTableViewCellThumbnailOffset = 50.0;
                                    _titleLabel.frame.size.height + _dateLabel.frame.size.height);
     CGFloat totalHeightOfCellWithLabels = totalHeightOfLabels +
                                         (self.frame.size.height - totalHeightOfLabels);
-    CGFloat horizontalCenterOfCell = totalHeightOfCellWithLabels / 2;
-    CGFloat yCoordOfThumbnail = horizontalCenterOfCell - (45.0 / 2);
+    CGFloat verticalHeight = totalHeightOfCellWithLabels / 2;
+    CGFloat yCoordOfThumbnail = verticalHeight - (45.0 / 2);
     
     _imgView.frame = CGRectMake(NewPostTableViewCellStandardOffset,
                                 yCoordOfThumbnail, 45.0, 45.0);
@@ -222,8 +222,6 @@ CGFloat const NewPostTableViewCellThumbnailOffset = 50.0;
 
 + (NSString *)titleText:(AbstractPost *)post
 {
-    NSLog(@"POST Contentents: %@", [post description]);
-    
     NSString *title = [[post valueForKey:@"postTitle"] stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]];
     if (title == nil || ([title length] == 0)) {
         title = NSLocalizedString(@"(no title)", @"");
@@ -294,7 +292,7 @@ CGFloat const NewPostTableViewCellThumbnailOffset = 50.0;
         if (IS_IOS7 && IS_RETINA) {
             return CGRectMake(NewPostTableViewCellStandardOffset + NewPostTableViewCellLabelAndTitleHorizontalOffset + NewPostTableViewCellThumbnailOffset, NewPostTableViewCellStandardOffset, size.width, size.height);
         } else {
-            return CGRectMake(NewPostTableViewCellStandardOffset, NewPostTableViewCellStandardOffset, size.width, size.height);
+            return CGRectMake(NewPostTableViewCellStandardOffset + NewPostTableViewCellThumbnailOffset, NewPostTableViewCellStandardOffset, size.width, size.height);
         }
     } else {
         return CGRectMake(0, NewPostTableViewCellStandardOffset, 0, 0);
@@ -318,7 +316,7 @@ CGFloat const NewPostTableViewCellThumbnailOffset = 50.0;
     if (IS_IOS7 && IS_RETINA) {
         return CGRectMake(NewPostTableViewCellStandardOffset + NewPostTableViewCellLabelAndTitleHorizontalOffset + NewPostTableViewCellThumbnailOffset, CGRectGetMaxY(previousFrame) + offset, size.width, size.height);
     } else {
-        return CGRectIntegral(CGRectMake(NewPostTableViewCellStandardOffset, CGRectGetMaxY(previousFrame) + offset, size.width, size.height));
+        return CGRectIntegral(CGRectMake(NewPostTableViewCellStandardOffset + NewPostTableViewCellThumbnailOffset, CGRectGetMaxY(previousFrame) + offset, size.width, size.height));
     }
 }
 

--- a/WordPress/Classes/PostTableViewCell.h
+++ b/WordPress/Classes/PostTableViewCell.h
@@ -25,7 +25,7 @@
 
 @interface PostTableViewCell : UITableViewCell {
     AbstractPost *__weak post;
-
+    
     UILabel *nameLabel;
     UILabel *dateLabel;
 	UILabel *statusLabel;

--- a/WordPress/Classes/PostTableViewCell.m
+++ b/WordPress/Classes/PostTableViewCell.m
@@ -109,6 +109,8 @@ static const float statusLabelMaxWidthPortrait = 100.f;
     @catch (NSException * e) {
         saving = NO;
     }
+    
+
 }
 
 - (void)layoutSubviews {


### PR DESCRIPTION
Completed the task. I've added the corresponding thumbnail to the UITableViewCell in the NewPostsTableView. The thumbnail will always be vertically centered no matter the size of the cell or the contents of the cell. If there is no image the appIcon is displayed (didn't know what I should do if there wasn't an image). I've tested this on iOS7 iPhone 3.5inch retina. 
